### PR TITLE
Improve navigation and refresh portfolio content

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -29,14 +29,14 @@ const AboutSection = () => {
   return (
     <section className="py-20 px-6 relative">
       <div className="container mx-auto max-w-6xl">
-        <div className="text-center mb-16 animate-fade-in">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6 hover:scale-105 transition-transform duration-300">
-            <span className="text-gradient">About Me</span>
-          </h2>
-          <p className="text-xl text-gray-300 max-w-2xl mx-auto leading-relaxed">
-            4+ years building robust data infrastructure and analytics solutions for business growth.
-          </p>
-        </div>
+          <div className="text-center mb-16 animate-fade-in">
+            <h2 className="text-4xl md:text-5xl font-bold mb-6 hover:scale-105 transition-transform duration-300">
+              <span className="text-gradient">About Me</span>
+            </h2>
+            <p className="text-xl text-gray-300 max-w-2xl mx-auto leading-relaxed">
+              Data engineer with 4+ years designing cloud-native pipelines and analytics for international teams.
+            </p>
+          </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
           {highlights.map((item, index) => (
@@ -58,11 +58,10 @@ const AboutSection = () => {
 
         <div className="glass-effect rounded-2xl p-8 border-gray-700 animate-fade-in hover:border-blue-500/50 transition-all duration-300">
           <div className="text-center">
-            <h3 className="text-2xl font-bold text-white mb-4 hover:text-blue-300 transition-colors duration-300">My Approach</h3>
-            <p className="text-gray-300 max-w-3xl mx-auto">
-              Building data solutions that are scalable, maintainable, and aligned with business objectives. 
-              From data ingestion to visualization, every component works harmoniously to deliver actionable insights.
-            </p>
+              <h3 className="text-2xl font-bold text-white mb-4 hover:text-blue-300 transition-colors duration-300">My Approach</h3>
+              <p className="text-gray-300 max-w-3xl mx-auto">
+                I prioritize simple, cloud‑first architectures that teams can own. Pipelines are automated with dbt and Airflow, infrastructure is codified with Terraform, and dashboards in Looker, PowerBI or Preset keep insights accessible. I also tinker with scrapers that gather real-time data using Selenium and BeautifulSoup.
+              </p>
           </div>
         </div>
       </div>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -37,15 +37,14 @@ const ContactSection = () => {
   ];
 
   return (
-    <section className="py-20 px-6 relative">
+    <section id="contact" className="py-20 px-6 relative">
       <div className="container mx-auto max-w-6xl">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-4xl md:text-5xl font-bold mb-6">
             <span className="text-gradient">Let's Work Together</span>
           </h2>
           <p className="text-xl text-gray-300 max-w-3xl mx-auto">
-            Ready to transform your data infrastructure? Let's discuss how I can help 
-            your business unlock the power of data.
+            Have an idea or a challenge? Let's connect and explore how data can move your business forward.
           </p>
         </div>
 
@@ -55,8 +54,7 @@ const ContactSection = () => {
             <div>
               <h3 className="text-2xl font-bold text-white mb-6">Get In Touch</h3>
               <p className="text-gray-300 mb-8">
-                I'm always interested in discussing new opportunities and challenging projects. 
-                Whether you need a complete data platform or specific consulting, I'm here to help.
+                I'm always happy to talk about new opportunities and tough problems. Whether you need a full data platform or quick advice, I'm here to help.
               </p>
             </div>
 

--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -10,20 +10,20 @@ const ExperienceSection = () => {
       period: "Apr 2024 - Present",
       location: "Remote",
       achievements: [
-        "Built data pipelines processing TB of information daily",
-        "Reduced data processing costs by 80% through optimization",
-        "Migrated old data stacks to DBT in Databricks and Snowflake"
+        "Scaled streaming and batch pipelines handling terabytes daily for one of Europe's largest retailers",
+        "Moved dozens of legacy workflows into dbt orchestrated with Airflow on Databricks and Snowflake, cutting costs by up to 80%",
+        "Delivered self-serve analytics through Looker dashboards for one of its biggest customers"
       ]
     },
     {
       role: "Senior Data Engineer",
-      company: "BeonX",
-      period: "Oct 2023 - Mar 2024",
+      company: "BEONx",
+      period: "Oct 2023 - Apr 2024",
       location: "Remote",
       achievements: [
-        "Migrated data pipelines to DBT + Airflow",
-        "Managed datasets from thousands of customers",
-        "Set the foundations to build Data Lakes with Analytics"
+        "Migrated cloud pipelines to AWS with dbt and Airflow to share data across teams",
+        "Handled terabytes of hotel revenue data, improving pipeline efficiency by 50%",
+        "Established the foundations for the company's first data lake architecture"
       ]
     },
     {
@@ -32,22 +32,33 @@ const ExperienceSection = () => {
       period: "Apr 2021 - Oct 2023",
       location: "Barcelona, Spain",
       achievements: [
-        "Developed data products collaborating on an open-source project: Qbeast format",
-        "Built a data platform to manage pipelines with DBT",
-        "Optimized customer pipelines reducing costs by more than 70%"
+        "Designed data lake products and cloud infrastructure while moving toward a Tech Lead role",
+        "Implemented data models, quality checks and team workflows using AWS, Kubernetes and dbt",
+        "Collaborated with stakeholders through dashboards in Looker and PowerBI"
+      ]
+    },
+    {
+      role: "Junior Big Data Engineer",
+      company: "Qbeast",
+      period: "Apr 2021 - Apr 2022",
+      location: "Barcelona, Spain",
+      achievements: [
+        "Contributed to the open-source qbeast-spark data lake format",
+        "Gained hands-on experience with data lake internals and multiple storage formats",
+        "Practiced agile collaboration using Kubernetes, Python, Scala, SQL and Git"
       ]
     }
   ];
 
   return (
-    <section className="py-20 px-6 relative">
+    <section id="experience" className="py-20 px-6 relative">
       <div className="container mx-auto max-w-6xl">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-4xl md:text-5xl font-bold mb-6 hover:scale-105 transition-transform duration-300">
             <span className="text-gradient">Experience</span>
           </h2>
           <p className="text-xl text-gray-300 max-w-2xl mx-auto">
-            A track record of delivering data solutions that drive business value
+            Highlights from building data platforms that empower global teams
           </p>
         </div>
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -40,19 +40,24 @@ const HeroSection = () => {
             Transforming data into powerful insights through scalable pipelines and advanced analytics.
           </p>
           
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center animate-slide-in-right" style={{ animationDelay: '0.6s' }}>
-            <Button 
-              size="lg" 
+          <div
+            className="flex flex-col sm:flex-row gap-4 justify-center items-center animate-slide-in-right"
+            style={{ animationDelay: '0.6s' }}
+          >
+            <Button
+              asChild
+              size="lg"
               className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 text-lg animate-pulse-glow hover:scale-105 transition-all duration-300"
             >
-              View My Work
+              <a href="#experience">View My Work</a>
             </Button>
-            <Button 
-              variant="outline" 
+            <Button
+              asChild
+              variant="outline"
               size="lg"
               className="border-gray-600 text-gray-300 hover:bg-gray-800 hover:border-blue-500 px-8 py-3 text-lg hover:scale-105 transition-all duration-300"
             >
-              Get In Touch
+              <a href="#contact">Get In Touch</a>
             </Button>
           </div>
         </div>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -4,39 +4,37 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 const SkillsSection = () => {
   const skillCategories = [
     {
-      title: "Programming Languages",
+      title: "Data Engineering",
+      skills: [
+        { name: "dbt", level: 92 },
+        { name: "Apache Airflow", level: 90 },
+        { name: "Data Lakes", level: 88 },
+        { name: "ETLs", level: 85 }
+      ]
+    },
+    {
+      title: "Programming & Cloud",
       skills: [
         { name: "Python", level: 95 },
-        { name: "SQL", level: 98 },
-        { name: "Scala", level: 85 },
-        { name: "R", level: 80 }
-      ]
-    },
-    {
-      title: "Big Data & Processing",
-      skills: [
-        { name: "Apache Spark", level: 90 },
-        { name: "Apache Kafka", level: 85 },
-        { name: "Apache Airflow", level: 92 },
-        { name: "Hadoop", level: 80 }
-      ]
-    },
-    {
-      title: "Cloud Platforms",
-      skills: [
+        { name: "SQL & NoSQL", level: 93 },
         { name: "AWS", level: 90 },
-        { name: "Google Cloud", level: 85 },
-        { name: "Azure", level: 80 },
-        { name: "Snowflake", level: 88 }
+        { name: "Kubernetes", level: 85 }
       ]
     },
     {
-      title: "Databases & Storage",
+      title: "Databases & Extraction",
       skills: [
-        { name: "PostgreSQL", level: 95 },
-        { name: "MongoDB", level: 85 },
-        { name: "Redis", level: 80 },
-        { name: "Elasticsearch", level: 82 }
+        { name: "PostgreSQL", level: 92 },
+        { name: "AWS Glue", level: 80 },
+        { name: "Web Scraping", level: 78 }
+      ]
+    },
+    {
+      title: "Analytics & Leadership",
+      skills: [
+        { name: "Data Visualization", level: 85 },
+        { name: "Machine Learning", level: 75 },
+        { name: "Project Management", level: 80 }
       ]
     }
   ];
@@ -48,9 +46,9 @@ const SkillsSection = () => {
           <h2 className="text-4xl md:text-5xl font-bold mb-6">
             <span className="text-gradient">Technical Skills</span>
           </h2>
-          <p className="text-xl text-gray-300 max-w-3xl mx-auto">
-            A comprehensive toolkit for modern data engineering challenges
-          </p>
+            <p className="text-xl text-gray-300 max-w-3xl mx-auto">
+              Tools I rely on to build reliable, scalable data platforms
+            </p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,9 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
-
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,10 @@
     @apply border-border;
   }
 
+  html {
+    scroll-behavior: smooth;
+  }
+
   body {
     @apply bg-background text-foreground;
     background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e  100%);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,6 @@
 
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -144,5 +145,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Expand “My Approach” with dashboard tooling and personal scraping projects
- Refine MANGO experience bullets and correct Qbeast tenure
- Enrich skills with ETL emphasis and new databases/extraction category while fixing lint issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e9d5a1f0832c9f85def086c3dfcd